### PR TITLE
Fix #11: 支持设置工作目录

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,10 +11,11 @@ import (
 func main() {
 	interval := flag.Duration("interval", 30*time.Minute, "执行间隔，如 30s, 30m, 30h")
 	prompt := flag.String("prompt", "在 jihulab 上处理 linzh17-group/linzh17-project 的 open issues", "传递给 amp 的 prompt")
+	workDir := flag.String("workdir", "", "工作目录，默认为当前程序执行目录")
 	flag.Parse()
 
 	// 首次执行
-	runTask(*prompt)
+	runTask(*prompt, *workDir)
 
 	// 定时执行
 	ticker := time.NewTicker(*interval)
@@ -23,13 +24,13 @@ func main() {
 	fmt.Printf("[%s] 定时任务已启动，每 %s 执行一次\n", time.Now().Format("2006-01-02 15:04:05"), *interval)
 
 	for range ticker.C {
-		runTask(*prompt)
+		runTask(*prompt, *workDir)
 	}
 }
 
 var execCommand = exec.Command
 
-func runTask(prompt string) {
+func runTask(prompt string, workDir string) {
 	fmt.Printf("[%s] 开始执行任务...\n", time.Now().Format("2006-01-02 15:04:05"))
 
 	cmd := execCommand("amp", "-x",
@@ -42,8 +43,14 @@ func runTask(prompt string) {
 		"AMP_API_KEY=your-api-key-1",
 	)
 
-	// 设置工作目录（如果需要）
-	cmd.Dir = "/Users/lzh17/Projects/gitlab_auto_test/corn_amp"
+	// 设置工作目录：如果未指定，则使用当前程序执行目录
+	if workDir != "" {
+		cmd.Dir = workDir
+	} else {
+		if cwd, err := os.Getwd(); err == nil {
+			cmd.Dir = cwd
+		}
+	}
 
 	// 捕获输出
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
## 解决 Issue #11

**问题**: 工作目录硬编码为 `/Users/lzh17/Projects/gitlab_auto_test/corn_amp`，不支持传入

**修改内容**:
- 新增 `-workdir` 命令行参数
- 默认使用 `os.Getwd()` 获取当前程序执行目录
- 移除了硬编码的工作目录路径

**使用方法**:
- 使用当前目录: `./auto_issues`
- 指定工作目录: `./auto_issues -workdir /path/to/dir`
